### PR TITLE
Implement community feedback: UI improvements and location type simplification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MRS Lead Toolkit is a web-based operations tool for Medrunner staff in Star Citizen. It provides three main features:
+1. **Ship Assignment** - Manage team ship assignments with Discord-formatted output
+2. **After Action Report (AAR)** - Generate structured mission reports
+3. **Tip Splitter** - Calculate fair tip distribution accounting for Star Citizen's 0.5% transfer fee
+
+## Architecture
+
+Static HTML/CSS/JS application using Tailwind CSS (CDN). No build step required.
+
+### JavaScript Module Structure
+
+All modules use global functions (not ES6 modules) and share state via global variables.
+
+```
+js/
+├── constants.js      # Discord emojis, fallback ship list, shared SHIPS array
+├── ships-api.js      # FleetYards API integration, ship list caching (24hr localStorage)
+├── ship-assignment.js # Ship/crew state, drag-drop, Discord import/export parsing
+├── aar.js            # AAR form logic, embedded LOCATIONS_DATABASE, custom dropdowns
+├── tip-splitter.js   # Fee-aware tip distribution algorithm
+├── ui.js             # Tab switching, cross-module UI coordination
+└── main.js           # DOMContentLoaded initialization, conditional field setup
+```
+
+### Key Global Variables
+
+- `ships` (ship-assignment.js) - Array of ship objects with crew assignments
+- `SHIPS` (constants.js) - Populated from FleetYards API or fallback list
+- `PLANETARY_BODIES` / `PLANETARY_BODY_TO_POIS` (aar.js) - Location data for AAR
+- `tipRecipients` (tip-splitter.js) - Recipients for tip calculations
+
+### External Dependencies
+
+- **Tailwind CSS** - Loaded via CDN, configured inline in index.html
+- **Google Fonts** - Inter and Mohave font families
+- **FleetYards API** - `https://api.fleetyards.net/v1/models` for Star Citizen ship data
+
+## Development
+
+Open `index.html` directly in a browser. No server required for basic development.
+
+### Deployment
+
+GitHub Pages auto-deploys on push to `main` branch via `.github/workflows/static.yml`.
+
+### Custom UI Components
+
+The app uses custom dropdown/select components (not native `<select>`) with search functionality. These are initialized via `initializeCustomSelect()`, `initializeAARSelect()`, `initializeAARPlanetSelect()`, `initializeAARPOISelect()`, and `initializeExtractedToSelect()`. When modifying these, note:
+- Event listeners are cloned/replaced to prevent duplicates
+- Dropdowns close when clicking outside via document-level listeners
+
+### Discord Message Format
+
+Ship assignments output uses custom Discord emoji syntax: `<:EmojiName:EmojiID>`. The emoji mappings are in `EMOJIS` constant (constants.js). Import parsing handles both `<:P5:...>` and `:P5:` formats.
+
+### Tip Splitter Algorithm
+
+The core algorithm in `findEqualTakeHomeAmount()` ensures all recipients receive equal take-home amounts by iteratively finding the maximum share that fits within the total pool after accounting for:
+- 0.5% transfer fee (rounded UP per transfer)
+- Lead keeps their share fee-free
+- Logistics donations pooled into single transfer

--- a/index.html
+++ b/index.html
@@ -72,27 +72,14 @@
         <!-- SHIP ASSIGNMENT TAB -->
         <div id="content-shipAssignment" class="tab-content">
 
-        <!-- Import from Discord Card -->
-        <div class="mb-6 rounded-lg border border-gray-700 bg-mrs-box p-5 shadow-lg md:p-6">
-            <h2 class="mb-4 font-mohave text-2xl font-semibold uppercase tracking-wide text-white">Import from Discord</h2>
-            <p class="mb-4 rounded-lg border border-blue-900 bg-blue-950/50 p-3 text-sm text-gray-300">
-                💡 <strong class="text-white">Paste a Discord ship assignment message</strong> below to automatically populate the ship assignments. This is useful for team lead hand-overs.
-            </p>
-            <textarea id="import-discord-message" rows="8" placeholder="Paste your Discord ship assignment message here..." class="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-gray-200 font-mono transition focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"></textarea>
-            <div class="mt-3 flex gap-3">
-                <button onclick="importFromDiscord()" class="flex-1 rounded-lg border border-mrs-button bg-mrs-button px-5 py-2.5 text-sm font-medium text-white shadow-md transition hover:border-mrs-button-hover hover:bg-mrs-button-hover">Import & Populate</button>
-                <button onclick="document.getElementById('import-discord-message').value = ''" class="rounded-lg border border-gray-600 bg-gray-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-gray-600">Clear</button>
-            </div>
-            <div id="import-status" class="mt-3 hidden rounded-lg px-4 py-3 text-center font-medium"></div>
-        </div>
-
-        <!-- Ship Groups Card -->
+        <!-- Ship Groups Card (Primary) -->
         <div class="mb-6 rounded-lg border border-gray-700 bg-mrs-box p-5 shadow-lg md:p-6">
             <div class="mb-4 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
                 <h2 class="font-mohave text-2xl font-semibold uppercase tracking-wide text-white">Ship Groups</h2>
-                <div class="flex w-full items-center gap-3 md:w-auto">
+                <div class="flex w-full flex-wrap items-center gap-3 md:w-auto">
                     <span id="apiStatus" class="flex-1 rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-xs font-medium text-gray-300 md:flex-auto">Loading ships...</span>
                     <button class="rounded-lg border border-mrs-button bg-mrs-button px-4 py-2 text-sm font-medium text-white transition hover:border-mrs-button-hover hover:bg-mrs-button-hover" onclick="refreshShipList()">Refresh Ships</button>
+                    <button class="rounded-lg border border-gray-600 bg-gray-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-600" onclick="openImportModal()">Import from Discord</button>
                 </div>
             </div>
             <p class="mb-5 rounded-lg border border-blue-900 bg-blue-950/50 p-3 text-sm text-gray-300">
@@ -213,43 +200,44 @@
                                     <div class="custom-select-options custom-scrollbar max-h-60 overflow-y-auto" id="aar-planet-options"></div>
                                 </div>
                             </div>
+                            <input type="text" id="aar-planet-other" placeholder="Specify planetary body..." class="mt-2 w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-gray-200 transition focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 hidden">
                         </div>
 
                         <!-- Location Type -->
                         <div>
                             <label class="mb-2 block text-sm font-medium text-gray-300">Location Type</label>
-                            <select id="aar-location-type" class="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-gray-200 transition focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
-                                <option value="">Select type...</option>
-                                <option value="Landing Zone / City">Landing Zone / City</option>
-                                <option value="Settlement">Settlement</option>
-                                <option value="Outpost">Outpost</option>
-                                <option value="Space Station">Space Station</option>
-                                <option value="Lagrange Station">Lagrange Station</option>
-                                <option value="Jump Point Station">Jump Point Station</option>
-                                <option value="Bunker (Corporate)">Bunker (Corporate)</option>
-                                <option value="Bunker (Outlaw)">Bunker (Outlaw)</option>
-                                <option value="Bunker (Abandoned)">Bunker (Abandoned)</option>
-                                <option value="Security Post">Security Post</option>
-                                <option value="Mining Facility">Mining Facility</option>
-                                <option value="Processing Facility">Processing Facility</option>
-                                <option value="Distribution Center">Distribution Center</option>
-                                <option value="Data Center">Data Center</option>
-                                <option value="Research Outpost">Research Outpost</option>
-                                <option value="Agricultural / Farm">Agricultural / Farm</option>
-                                <option value="Aid Shelter">Aid Shelter</option>
-                                <option value="Salvage Yard">Salvage Yard</option>
-                                <option value="Cave System">Cave System</option>
-                                <option value="Derelict / Wreck">Derelict / Wreck</option>
-                                <option value="Communication Array">Communication Array</option>
-                                <option value="Prison / Rehabilitation">Prison / Rehabilitation</option>
-                                <option value="Racetrack">Racetrack</option>
-                                <option value="Pickup">Pickup</option>
-                                <option value="Stranded">Stranded</option>
-                                <option value="Open Space">Open Space</option>
-                                <option value="Planet Surface">Planet Surface</option>
-                                <option value="PVP Zone">PVP Zone</option>
-                                <option value="Other">Other</option>
-                            </select>
+                            <div class="custom-select-wrapper relative" id="aar-location-type-select">
+                                <div class="custom-select-trigger relative flex w-full cursor-pointer items-center justify-between rounded-md border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-gray-200 transition hover:border-primary-500">
+                                    <span class="custom-select-value truncate pr-4" id="aar-location-type-value">Select type...</span>
+                                    <svg class="custom-select-arrow absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 transition-transform duration-200" viewBox="0 0 20 20" fill="currentColor">
+                                        <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                                    </svg>
+                                </div>
+                                <div class="custom-select-dropdown absolute left-0 right-0 top-full z-50 mt-1 hidden overflow-hidden rounded-md border border-gray-600 bg-gray-700 shadow-lg">
+                                    <div class="border-b border-gray-600 bg-gray-800 p-2">
+                                        <input type="text" placeholder="Search location types..." class="location-type-search-input w-full rounded-md border border-gray-600 bg-gray-900 px-3 py-1.5 text-sm text-gray-200 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                                    </div>
+                                    <div class="custom-select-options custom-scrollbar max-h-60 overflow-y-auto" id="aar-location-type-options">
+                                        <!-- Alphabetically sorted -->
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="ASD Facility">ASD Facility</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Bunker">Bunker</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Cave System">Cave System</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Communications Array">Communications Array</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Contested Zone">Contested Zone</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Distribution Centre">Distribution Centre</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Landing Zone / City">Landing Zone / City</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Mining Base (Space)">Mining Base (Space)</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Mining Outpost">Mining Outpost</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="OLP / PAF">OLP / PAF</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Open Space">Open Space</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Outpost">Outpost</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Planet Surface">Planet Surface</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Security Post Kareah (SPK)">Security Post Kareah (SPK)</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white" data-value="Space Station">Space Station</div>
+                                        <div class="custom-select-option cursor-pointer px-3 py-2 text-sm text-gray-300 hover:bg-mrs-button hover:text-white border-t border-gray-600 mt-1 pt-2" data-value="Other">Other (specify below)</div>
+                                    </div>
+                                </div>
+                            </div>
                             <input type="text" id="aar-location-type-other" placeholder="Specify location type..." class="mt-2 w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-gray-200 transition focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 hidden">
                         </div>
 
@@ -566,6 +554,28 @@
         <!-- END TIP SPLITTER TAB -->
     </div>
 
+    <!-- Import from Discord Modal -->
+    <div id="import-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black/70 p-4">
+        <div class="w-full max-w-2xl rounded-lg border border-gray-700 bg-mrs-box p-6 shadow-xl">
+            <div class="mb-4 flex items-center justify-between">
+                <h2 class="font-mohave text-2xl font-semibold uppercase tracking-wide text-white">Import from Discord</h2>
+                <button onclick="closeImportModal()" class="rounded-lg p-2 text-gray-400 transition hover:bg-gray-700 hover:text-white">
+                    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+            <p class="mb-4 rounded-lg border border-blue-900 bg-blue-950/50 p-3 text-sm text-gray-300">
+                💡 <strong class="text-white">Paste a Discord ship assignment message</strong> below to automatically populate the ship assignments. This is useful for team lead hand-overs.
+            </p>
+            <textarea id="import-discord-message" rows="10" placeholder="Paste your Discord ship assignment message here..." class="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-gray-200 font-mono transition focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"></textarea>
+            <div id="import-status" class="mt-3 hidden rounded-lg px-4 py-3 text-center font-medium"></div>
+            <div class="mt-4 flex gap-3">
+                <button onclick="importFromDiscord()" class="flex-1 rounded-lg border border-mrs-button bg-mrs-button px-5 py-2.5 text-sm font-medium text-white shadow-md transition hover:border-mrs-button-hover hover:bg-mrs-button-hover">Import & Populate</button>
+                <button onclick="closeImportModal()" class="rounded-lg border border-gray-600 bg-gray-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-gray-600">Cancel</button>
+            </div>
+        </div>
+    </div>
 
     <!-- Application JavaScript Modules -->
     <script src="js/constants.js"></script>

--- a/js/ship-assignment.js
+++ b/js/ship-assignment.js
@@ -918,8 +918,10 @@ function importFromDiscord() {
 
         showImportStatus("success", `Successfully imported ${parsedShips.length} ship(s) with ${parsedShips.reduce((sum, s) => sum + s.crew.length, 0)} crew member(s)!`);
 
-        // Clear the import textarea
-        document.getElementById("import-discord-message").value = "";
+        // Close modal after a brief delay to show success message
+        setTimeout(() => {
+            closeImportModal();
+        }, 1500);
     } catch (error) {
         console.error("Import error:", error);
         showImportStatus("error", "Failed to parse message: " + error.message);
@@ -1078,6 +1080,49 @@ function showImportStatus(type, message) {
     setTimeout(() => {
         statusEl.classList.add("hidden");
     }, 5000);
+}
+
+// ============================================================================
+// IMPORT MODAL FUNCTIONS
+// ============================================================================
+
+/**
+ * Opens the Import from Discord modal.
+ * Displays the modal overlay with flex centering.
+ *
+ * @function openImportModal
+ */
+function openImportModal() {
+    const modal = document.getElementById("import-modal");
+    if (modal) {
+        modal.classList.remove("hidden");
+        modal.classList.add("flex");
+        // Focus the textarea
+        const textarea = document.getElementById("import-discord-message");
+        if (textarea) {
+            textarea.focus();
+        }
+    }
+}
+
+/**
+ * Closes the Import from Discord modal.
+ * Hides the modal and clears any status messages.
+ *
+ * @function closeImportModal
+ */
+function closeImportModal() {
+    const modal = document.getElementById("import-modal");
+    if (modal) {
+        modal.classList.add("hidden");
+        modal.classList.remove("flex");
+        // Clear the textarea and status
+        document.getElementById("import-discord-message").value = "";
+        const statusEl = document.getElementById("import-status");
+        if (statusEl) {
+            statusEl.classList.add("hidden");
+        }
+    }
 }
 
 // ============================================================================

--- a/js/ui.js
+++ b/js/ui.js
@@ -60,11 +60,12 @@ function switchTab(tabName) {
     // If switching to AAR tab, populate ship dropdowns and re-initialize location dropdowns
     if (tabName === "aar") {
         populateAARShipDropdowns();
-        // Re-initialize planet and POI dropdowns to ensure event listeners are attached
+        // Re-initialize dropdowns to ensure event listeners are attached
         if (PLANETARY_BODIES.length > 0) {
             initializeAARPlanetSelect();
         }
         initializeAARPOISelect();
+        initializeAARLocationTypeSelect();
     }
 }
 


### PR DESCRIPTION
## Summary
- Reorder Ship Assignment tab: Ship Groups now appears first
- Convert Import from Discord to modal popup
- Simplify Location Types dropdown from 28 to 16 options
- Make Location Type dropdown searchable with alphabetical sorting
- Add "Other" option to Planetary Body dropdown

## Test plan
- [ ] Open index.html and verify Ship Groups card appears first
- [ ] Click "Import from Discord" button - modal should open
- [ ] Test importing a Discord message - modal closes after success
- [ ] Go to AAR tab, verify location types are alphabetized and searchable
- [ ] Select "Other" for Planetary Body - text input should appear

🤖 Generated with [Claude Code](https://claude.ai/code)